### PR TITLE
Update config to be compatible with hugo v0.144.2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,10 +4,12 @@ baseURL = "/"
 title = "Hugo Themes"
 author = "Steve Francia"
 copyright = "Copyright © 2008–2019, Steve Francia and the Hugo Authors; all rights reserved."
-paginate = 4
 languageCode = "en"
 DefaultContentLanguage = "en"
 enableInlineShortcodes = true
+
+[pagination]
+  paperSize = 3
 
 [menu]
 


### PR DESCRIPTION
# Description

This PR fixes this error:
```
ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and subsequently removed.
Use pagination.pagerSize instead.
```